### PR TITLE
modify verified callback and fix lang option

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -81,11 +81,10 @@ WechatStrategy.prototype.authenticate = function (req, options) {
     self._oauth.getAccessToken(code, function (err, response) {
 
       // 校验完成信息
-      function verified(err, profile) {
-        if (err) {
-          return self.error(err);
-        }
-        return self.success(profile);
+      function verified(err, user, info) {
+        if (err) { return self.error(err); }
+        if (!user) { return self.fail(info); }
+        self.success(user, info);
       }
 
       if (err) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -39,7 +39,7 @@ function WechatStrategy(options, verify) {
   this._verify = verify;
   this._oauth = new OAuth(options.appID, options.appSecret);
   this._callbackURL = options.callbackURL;
-  this.lang = options.lang || 'zh-CN';
+  this._lang = options.lang || 'en';
   this._state = options.state;
   this._scope = options.scope || 'snsapi_userinfo';
   this._passReqToCallback = options.passReqToCallback;
@@ -111,7 +111,7 @@ WechatStrategy.prototype.authenticate = function (req, options) {
           return self.error(ex);
         }
       } else {
-        self._oauth.getUser(params['openid'], function (err, profile) {
+        self._oauth.getUser({ openid: params['openid'], lang: self._lang }, function (err, profile) {
           if (err) {
             debug('fetch userinfo by openid error ->', err.message);
             return self.error(err);


### PR DESCRIPTION
modify the verify callback to enable this type of callback: 
```javascript 
done(null, false, { message: 'error message' });
```
and fix lang option:
```javascript
passport.use(new WechatStrategy({
    appID: {APPID},
    name:{默认为wechat,可以设置组件的名字}
    appSecret: {APPSECRET},
    client:{wechat|web},
    callbackURL: {CALLBACKURL},
    scope: {snsapi_userinfo|snsapi_base},
    state:{STATE},
    lang: {en(default)|zh_CN|zh_TW} // fixed this option
  },
  function(accessToken, refreshToken, profile, done) {
    return done(err,profile);
  }
));
```